### PR TITLE
Testing fix for CVE 2019-0981

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -y && apt-get upgrade -y && useradd -m docker
 #### This is to fix CVE-2019-0981 - 
 #### Ubuntu 20.04 ships with azure-cli pre-installed and is outdated per https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux
 #### Creating a PR for now to test this fix
-RUN apt-get remove azure-cli -y && sudo apt-get autoremove -y
+RUN apt-get remove azure-cli -y &&  apt-get autoremove -y
 
 # install the packages and dependencies along with jq so we can parse JSON (add additional packages as necessary)
 RUN apt-get install -y --no-install-recommends curl nodejs wget unzip vim git azure-cli jq build-essential libssl-dev libffi-dev python3 python3-venv python3-dev python3-pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -y && apt-get upgrade -y && useradd -m docker
 #### This is to fix CVE-2019-0981 - 
 #### Ubuntu 20.04 ships with azure-cli pre-installed and is outdated per https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux
 #### Creating a PR for now to test this fix
-RUN apt remove azure-cli -y && sudo apt autoremove -y
+RUN apt-get remove azure-cli -y && sudo apt-get autoremove -y
 
 # install the packages and dependencies along with jq so we can parse JSON (add additional packages as necessary)
 RUN apt-get install -y --no-install-recommends curl nodejs wget unzip vim git azure-cli jq build-essential libssl-dev libffi-dev python3 python3-venv python3-dev python3-pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ RUN apt-get update -y && apt-get upgrade -y && useradd -m docker
 #### Ubuntu 20.04 ships with azure-cli pre-installed and is outdated per https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux
 #### Creating a PR for now to test this fix
 RUN apt-get remove azure-cli -y &&  apt-get autoremove -y
-
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 # install the packages and dependencies along with jq so we can parse JSON (add additional packages as necessary)
-RUN apt-get install -y --no-install-recommends curl nodejs wget unzip vim git azure-cli jq build-essential libssl-dev libffi-dev python3 python3-venv python3-dev python3-pip
+RUN apt-get install -y --no-install-recommends curl nodejs wget unzip vim git jq build-essential libssl-dev libffi-dev python3 python3-venv python3-dev python3-pip
 
 # cd into the user directory, download and unzip the github actions runner
 RUN cd /home/docker && mkdir actions-runner && cd actions-runner \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,11 @@ LABEL RunnerVersion=${RUNNER_VERSION}
 # update the base packages + add a non-sudo user
 RUN apt-get update -y && apt-get upgrade -y && useradd -m docker
 
+#### This is to fix CVE-2019-0981 - 
+#### Ubuntu 20.04 ships with azure-cli pre-installed and is outdated per https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux
+#### Creating a PR for now to test this fix
+RUN apt remove azure-cli -y && sudo apt autoremove -y
+
 # install the packages and dependencies along with jq so we can parse JSON (add additional packages as necessary)
 RUN apt-get install -y --no-install-recommends curl nodejs wget unzip vim git azure-cli jq build-essential libssl-dev libffi-dev python3 python3-venv python3-dev python3-pip
 


### PR DESCRIPTION
Trivy scanned the container and found 14 findings of ASP.net and DotNet core DOS findings (2019-0981). Creating separate branch and PR to test out this fix, rescan with Trivy, and see if my theory is correct on fixing this:

Per https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux